### PR TITLE
Added optional parameters to specify sda/scl pins.

### DIFF
--- a/Adafruit_FT6206.cpp
+++ b/Adafruit_FT6206.cpp
@@ -53,8 +53,12 @@ Adafruit_FT6206::Adafruit_FT6206() { touches = 0; }
     @returns True if an FT6206 is found, false on any failure
 */
 /**************************************************************************/
-boolean Adafruit_FT6206::begin(uint8_t thresh) {
-  Wire.begin();
+boolean Adafruit_FT6206::begin(uint8_t thresh, int sda, int scl) {
+  if(sda >= 0 && scl >= 0){
+    Wire.begin(sda, scl);
+  }else{
+    Wire.begin();
+  }
 
 #ifdef FT6206_DEBUG
   Serial.print("Vend ID: 0x");

--- a/Adafruit_FT6206.h
+++ b/Adafruit_FT6206.h
@@ -61,7 +61,7 @@ public:
 class Adafruit_FT6206 {
 public:
   Adafruit_FT6206(void);
-  boolean begin(uint8_t thresh = FT62XX_DEFAULT_THRESHOLD);
+  boolean begin(uint8_t thresh = FT62XX_DEFAULT_THRESHOLD, int sda=-1, int scl=-1);
   uint8_t touched(void);
   TS_Point getPoint(uint8_t n = 0);
 


### PR DESCRIPTION
**Scope**
Added optional parameters to Adafruit_FT6206::begin to specify the sda and scl pins used by the Wire.begin() function in both the [base arduino implementation](https://github.com/esp8266/Arduino/blob/master/libraries/Wire/Wire.h) as well as the [ESP32 implementation](https://github.com/espressif/arduino-esp32/blob/master/libraries/Wire/src/Wire.h).

**Limitations**
No known limitations; only added optional arguments and when specified they worked on my test device.

**Testing**
This unlocks this library's utility when using devices like the [WT32-SC01](https://www.seeedstudio.com/ESP32-Development-board-WT32-SC01-p-4735.html) which requires the sda/scl pins defined when using this library. Was able to get the TFT_eSPI keypad example responding to touch on a WT32-SC01 with minimal modification to the example sketch.