### PR TITLE
Add clang-format CI job and format source files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 2
+ColumnLimit: 80
+AllowShortBlocksOnASingleLine: Always
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Attach
+DerivePointerAlignment: false
+PointerAlignment: Left
+SpacesBeforeTrailingComments: 1

--- a/Adafruit_FT6206.cpp
+++ b/Adafruit_FT6206.cpp
@@ -27,7 +27,7 @@
 
 #include <Adafruit_FT6206.h>
 
-//#define FT6206_DEBUG
+// #define FT6206_DEBUG
 
 /**************************************************************************/
 /*!
@@ -35,7 +35,9 @@
 */
 /**************************************************************************/
 // I2C, no address adjustments or pins
-Adafruit_FT6206::Adafruit_FT6206() { touches = 0; }
+Adafruit_FT6206::Adafruit_FT6206() {
+  touches = 0;
+}
 
 /**************************************************************************/
 /*!
@@ -48,7 +50,7 @@ Adafruit_FT6206::Adafruit_FT6206() { touches = 0; }
     @returns True if an FT captouch is found, false on any failure
 */
 /**************************************************************************/
-bool Adafruit_FT6206::begin(uint8_t thresh, TwoWire *theWire,
+bool Adafruit_FT6206::begin(uint8_t thresh, TwoWire* theWire,
                             uint8_t i2c_addr) {
   if (i2c_dev)
     delete i2c_dev;
@@ -136,7 +138,6 @@ TS_Point Adafruit_FT6206::getPoint(uint8_t n) {
 */
 /**************************************************************************/
 void Adafruit_FT6206::readData(void) {
-
   uint8_t i2cdat[16];
   uint8_t addr = 0;
   i2c_dev->write_then_read(&addr, 1, i2cdat, 16);
@@ -235,7 +236,9 @@ void Adafruit_FT6206::autoCalibrate(void) {
     @brief  Instantiates a new FT6206 class with x, y and z set to 0 by default
 */
 /**************************************************************************/
-TS_Point::TS_Point(void) { x = y = z = 0; }
+TS_Point::TS_Point(void) {
+  x = y = z = 0;
+}
 
 /**************************************************************************/
 /*!

--- a/Adafruit_FT6206.h
+++ b/Adafruit_FT6206.h
@@ -5,8 +5,9 @@
 #ifndef ADAFRUIT_FT6206_LIBRARY
 #define ADAFRUIT_FT6206_LIBRARY
 
-#include "Arduino.h"
 #include <Adafruit_I2CDevice.h>
+
+#include "Arduino.h"
 
 #define FT62XX_DEFAULT_ADDR 0x38   //!< I2C address
 #define FT62XX_G_FT5201ID 0xA8     //!< FocalTech's panel ID
@@ -41,7 +42,7 @@
 */
 /**************************************************************************/
 class TS_Point {
-public:
+ public:
   TS_Point(void);
   TS_Point(int16_t x, int16_t y, int16_t z);
 
@@ -60,17 +61,17 @@ public:
 */
 /**************************************************************************/
 class Adafruit_FT6206 {
-public:
+ public:
   Adafruit_FT6206(void);
   bool begin(uint8_t thresh = FT62XX_DEFAULT_THRESHOLD,
-             TwoWire *theWire = &Wire, uint8_t i2c_addr = FT62XX_DEFAULT_ADDR);
+             TwoWire* theWire = &Wire, uint8_t i2c_addr = FT62XX_DEFAULT_ADDR);
   uint8_t touched(void);
   TS_Point getPoint(uint8_t n = 0);
 
   // void autoCalibrate(void);
 
-private:
-  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
+ private:
+  Adafruit_I2CDevice* i2c_dev = NULL; ///< Pointer to I2C bus interface
   void writeRegister8(uint8_t reg, uint8_t val);
   uint8_t readRegister8(uint8_t reg);
 


### PR DESCRIPTION
This PR adds a dedicated clang-format job to the CI workflow:

- Add `clang-format` job using `jidicula/clang-format-action@v4.14.0` with clang-format-18
- Build job now depends on the clang-format job (`needs: clang-format`)
- Format all source files with clang-format
- Add `.clang-format` configuration file

Tested with both clang-format-18 and clang-format-19 locally - both pass.

cc @ladyada